### PR TITLE
feat: Add GitHub Actions workflow for Pages deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,51 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ['main'] # Assuming 'main' is the default branch
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20 # Or your project's Node.js version
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Install dependencies
+        run: npm ci # Use 'npm ci' for cleaner installs in CI
+      - name: Build
+        run: npm run build # This will use the 'output: "export"' in next.config.ts
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: './out' # Next.js exports to the 'out' directory by default
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: 'export',
+  basePath: '/nextjs-project',
+  assetPrefix: '/nextjs-project/',
   /* config options here */
 };
 


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automatically build and deploy the Next.js application to GitHub Pages.

Key changes:
- Modified `next.config.ts` to enable static export (`output: 'export'`) and set `basePath` and `assetPrefix` to `/nextjs-project` for correct asset loading on GitHub Pages.
- Created `.github/workflows/deploy-pages.yml` with a workflow that:
    - Triggers on pushes to the `main` branch and allows manual dispatch.
    - Checks out the code.
    - Sets up Node.js (version 20).
    - Installs dependencies using `npm ci`.
    - Builds the Next.js application using `npm run build`.
    - Uploads the build artifact from the `out/` directory.
    - Deploys the artifact to GitHub Pages.