### PR TITLE
feat: Enhance shader-based audio visualizer

### DIFF
--- a/src/components/ShaderCanvas.tsx
+++ b/src/components/ShaderCanvas.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { useRef, useEffect } from 'react';
-import { Canvas } from '@react-three/fiber';
+import React, { useRef, useEffect, useMemo } from 'react'; // Added useMemo
+import { Canvas, useFrame } from '@react-three/fiber'; // Added useFrame
 import { ShaderMaterial, DoubleSide, Vector2 } from 'three';
 import { vertexShader, fragmentShader } from '@/domain/visualization/shaders';
 
@@ -13,11 +13,11 @@ export default function ShaderCanvas({ volume }: ShaderCanvasProps) {
   const materialRef = useRef<ShaderMaterial>(null);
 
   // Uniforms definition
-  // React.useMemo can be useful here if uniforms are complex, but for now, direct object is fine.
-  const uniforms = {
+  const uniforms = useMemo(() => ({
     u_volume: { value: 0.0 },
     u_resolution: { value: new Vector2(typeof window !== 'undefined' ? window.innerWidth : 0, typeof window !== 'undefined' ? window.innerHeight : 0) },
-  };
+    u_time: { value: 0.0 } // Added u_time
+  }), []); // Empty dependency array ensures uniforms object is created once
 
   useEffect(() => {
     if (materialRef.current) {
@@ -37,8 +37,13 @@ export default function ShaderCanvas({ volume }: ShaderCanvasProps) {
         handleResize(); // Initial set
         return () => window.removeEventListener('resize', handleResize);
     }
-  }, []);
+  }, [uniforms]); // Added uniforms to dependency array
 
+  useFrame((state) => {
+    if (materialRef.current && materialRef.current.uniforms.u_time) {
+      materialRef.current.uniforms.u_time.value = state.clock.elapsedTime;
+    }
+  });
 
   return (
     <div className="absolute top-0 left-0 w-full h-full -z-10 bg-gray-900"> {/* Keep bg for base */}

--- a/src/domain/visualization/shaders.ts
+++ b/src/domain/visualization/shaders.ts
@@ -9,12 +9,79 @@ export const vertexShader = `
 
 export const fragmentShader = `
   uniform float u_volume;
-  uniform vec2 u_resolution; // For more advanced effects later
+  uniform float u_time;
+  uniform vec2 u_resolution;
   varying vec2 vUv;
 
+  // Helper function for rotation
+  mat2 rotate2d(float angle){
+      return mat2(cos(angle), -sin(angle),
+                  sin(angle), cos(angle));
+  }
+
+  // Helper function for smoothstep-based shapes
+  // Creates a square shape, smoothstep controls the edge softness
+  float shape(vec2 p, float size, float smoothness) {
+      // abs(p) makes it symmetrical in all quadrants
+      // subtracting 'size' moves the shape boundary inwards
+      p = abs(p) - size; 
+      // max(p.x, p.y) gives a square shape from distance field logic
+      // smoothstep creates a smooth transition from 0 to 1 based on this distance
+      return smoothstep(0.0, smoothness, max(p.x, p.y));
+  }
+
   void main() {
-    float intensity = u_volume * 0.8 + 0.2; // Ensure it's visible even at low volume
-    // Make it a bit more interesting: pulsing blue based on volume
-    gl_FragColor = vec4(vUv.x * intensity * 0.5, vUv.y * intensity * 0.7, intensity, 1.0);
+      // Center UVs from (0,1) to (-1,1) and adjust for aspect ratio
+      vec2 uv = (vUv - 0.5) * 2.0;
+      float aspectRatio = u_resolution.x / u_resolution.y;
+      uv.x *= aspectRatio;
+
+      // Time-based rotation and scaling for dynamism
+      float timeScaled = u_time * 0.1; // Slow down time a bit
+      
+      // Rotate UV space based on time and volume
+      // More volume = faster rotation
+      uv = rotate2d(timeScaled * (0.3 + u_volume * 0.7)) * uv; 
+      
+      // Base pattern: multiple rotating, scaling shapes
+      float colorIntensity = 0.0;
+      // Shapes scale with volume, ensuring they don't disappear at low volume
+      float baseScale = 0.2 + u_volume * 0.3; 
+
+      for (int i = 0; i < 4; i++) { // Loop for 4 shapes
+          float i_float = float(i);
+          vec2 shapeUv = uv;
+          
+          // Each shape has a slightly different rotation speed and offset
+          shapeUv = rotate2d(timeScaled * 0.15 * (i_float + 1.0) + i_float * 0.5) * shapeUv;
+          
+          // Scale for each shape, with individual pulsating effect
+          float scale = baseScale * (1.0 - 0.15 * i_float);
+          scale *= (1.0 + sin(timeScaled * 2.0 + i_float * 1.5) * 0.15); // Pulsating size
+          
+          // Create a shape (inverted, so shape is bright)
+          // u_volume increases the sharpness/size of the shape effect
+          float s = 1.0 - shape(shapeUv * (1.5 + u_volume * 0.5), scale, 0.03);
+          // Accumulate intensity, weighted by volume
+          colorIntensity += s * (0.15 + u_volume * 0.35);
+      }
+
+      // Color mapping: create a vibrant, shifting color scheme
+      // Using trigonometric functions with time and volume to make colors dynamic
+      float r = sin(colorIntensity * 2.5 + timeScaled * 0.4 + u_volume * 0.5) * 0.5 + 0.5;
+      float g = cos(colorIntensity * 2.0 - timeScaled * 0.6 + u_volume * 0.8) * 0.5 + 0.5;
+      float b = sin(colorIntensity * 3.0 + timeScaled * 0.2 - u_volume * 0.3) * 0.5 + 0.5;
+
+      // Mix with a background color, more intense effect with higher volume
+      // The base color is a dark, slightly blue tone
+      vec3 baseBgColor = vec3(0.05, 0.05, 0.15);
+      // The dynamic color is mixed with the background
+      // smoothstep ensures that when colorIntensity is low, background is more visible
+      vec3 finalColor = mix(baseBgColor, vec3(r, g, b), smoothstep(0.0, 0.4, colorIntensity));
+      
+      // Further boost brightness based on overall volume, ensuring visibility
+      finalColor *= (0.4 + u_volume * 0.6);
+
+      gl_FragColor = vec4(finalColor, 1.0);
   }
 `;


### PR DESCRIPTION
This commit significantly enhances the audio visualizer by:

1.  **Updating Shader Logic:**
    - The fragment shader in `src/domain/visualization/shaders.ts` now implements a more dynamic and visually engaging effect.
    - It reacts to a `u_volume` uniform (derived from player volume) to change aspects like shape size, rotation speed, color intensity, and overall brightness.
    - It incorporates a `u_time` uniform for continuous time-based animations (e.g., pulsing, rotation), making the visualizer lively even with constant volume.

2.  **Modifying ShaderCanvas Component:**
    - `src/components/ShaderCanvas.tsx` now provides the `u_time` uniform to the shader.
    - The `u_time` uniform is updated on every frame using `@react-three/fiber`'s `useFrame` hook and `state.clock.elapsedTime`.
    - The `uniforms` object is now memoized using `React.useMemo` for stability and performance.
    - Dependency arrays for `useEffect` hooks have been updated accordingly.

The visualizer remains driven by the YouTube player's user-set volume, as direct access to raw audio data is restricted by browser security policies for cross-origin iframes. This enhancement focuses on maximizing the visual appeal based on the available volume information and time-based effects.