### PR TITLE
Fix: Resolve visualizer stuck on loading state

### DIFF
--- a/src/components/ShaderCanvas.tsx
+++ b/src/components/ShaderCanvas.tsx
@@ -17,10 +17,7 @@ export default function ShaderCanvas({ volume }: ShaderCanvasProps) {
     () => ({
       u_volume: { value: 0.0 },
       u_resolution: {
-        value: new Vector2(
-          typeof window !== "undefined" ? window.innerWidth : 0,
-          typeof window !== "undefined" ? window.innerHeight : 0,
-        ),
+        value: new Vector2(1, 1), // Initialize with placeholder non-zero values
       },
       u_time: { value: 0.0 }, // Added u_time
     }),
@@ -65,15 +62,10 @@ export default function ShaderCanvas({ volume }: ShaderCanvasProps) {
           <planeGeometry args={[20, 20]} /> {/* A large plane */}
           <shaderMaterial
             ref={materialRef}
-            args={[
-              {
-                // args should be an array containing the material properties object
-                uniforms,
-                vertexShader,
-                fragmentShader,
-                side: DoubleSide, // Render both sides of the plane
-              },
-            ]}
+            uniforms={uniforms}
+            vertexShader={vertexShader}
+            fragmentShader={fragmentShader}
+            side={DoubleSide}
           />
         </mesh>
       </Canvas>


### PR DESCRIPTION
This commit addresses an issue where the audio visualizer page was perpetually stuck on the "Loading Visualizer..." message.

The primary cause was identified as a potential division by zero in the fragment shader. This could occur if the `u_resolution` uniform (representing screen dimensions) was initialized with zero values before the browser had a chance to report the actual dimensions. The `ShaderCanvas` component's `u_resolution` uniform in `useMemo` is now initialized with placeholder `new Vector2(1, 1)` to prevent this. The correct dimensions are subsequently set by a `useEffect` hook.

Additionally, the props for the `shaderMaterial` in `ShaderCanvas.tsx` were refactored to be passed directly, aligning with common `@react-three/fiber` practices. This improves code clarity and robustness.

Linting and build checks were performed and passed successfully after these changes.